### PR TITLE
Support different languages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class firefox ($locale = 'en-US'){
   package { 'Firefox':
     provider   => 'appdmg',
-    source => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/19.0.2/mac/{$locale}/Firefox%2019.0.2.dmg"
+    source => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/19.0.2/mac/${locale}/Firefox%2019.0.2.dmg"
   }
 }


### PR DESCRIPTION
Hi,

i extended the firefox class with an $local option. en-US is the default ...

```
# Example

# Install Firefox in German.
class { 'firefox':
  locale => 'de'
}

```
