### PR TITLE
Update firefox versions for all classes

### DIFF
--- a/manifests/aurora.pp
+++ b/manifests/aurora.pp
@@ -5,7 +5,7 @@
 #   include firefox::aurora
 class firefox::aurora ($locale = 'en-US'){
   package { 'Firefox-Aurora':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-23.0a2.${locale}.mac.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-25.0a2.${locale}.mac.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/beta.pp
+++ b/manifests/beta.pp
@@ -5,7 +5,7 @@
 #   include firefox::beta
 class firefox::beta ($locale = 'en-US'){
   package { 'Firefox-Beta':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/22.0b2/mac/${locale}/Firefox%2022.0b2.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/24.0b4/mac/${locale}/Firefox%2024.0b4.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 #   include firefox
 class firefox($locale = 'en-US'){
   package { 'Firefox':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/22.0/mac/${locale}/Firefox%2022.0.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0/mac/${locale}/Firefox%2023.0.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/nightly.pp
+++ b/manifests/nightly.pp
@@ -5,7 +5,7 @@
 #   include firefox::nightly
 class firefox::nightly ($locale = 'en-US'){
   package { 'Firefox-Nightly':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-24.0a1.${locale}.mac.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-26.0a1.${locale}.mac.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/ux.pp
+++ b/manifests/ux.pp
@@ -5,7 +5,7 @@
 #   include firefox::ux
 class firefox::ux ($locale = 'en-US'){
   package { 'Firefox-UX':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-ux/firefox-24.0a1.${locale}.mac.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-ux/firefox-26.0a1.${locale}.mac.dmg",
     provider => 'appdmg'
   }
 }

--- a/spec/classes/firefox-aurora_spec.rb
+++ b/spec/classes/firefox-aurora_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::aurora' do
   it do
     should contain_class('firefox::aurora')
     should contain_package('Firefox-Aurora').with({
-      :source   =>  'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-23.0a2.en-US.mac.dmg',
+      :source   =>  'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-25.0a2.en-US.mac.dmg',
       :provider	=>	'appdmg'
     })
   end

--- a/spec/classes/firefox-beta.rb
+++ b/spec/classes/firefox-beta.rb
@@ -4,7 +4,7 @@ describe 'firefox::beta' do
   it do
     should contain_class('firefox::beta')
     should contain_package('Firefox-Beta').with({
-      :source	=> 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/22.0b2/mac/en-US/Firefox%2022.0b2.dmg',
+      :source	=> 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/24.0b4/mac/en-US/Firefox%2024.0b4.dmg',
       :provider	=> 'appdmg'
     })
   end

--- a/spec/classes/firefox-nightly_spec.rb
+++ b/spec/classes/firefox-nightly_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::nightly' do
   it do
     should contain_class('firefox::nightly')
     should contain_package('Firefox-Nightly').with({
-      :source	=>	'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-24.0a1.en-US.mac.dmg',
+      :source	=>	'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-26.0a1.en-US.mac.dmg',
       :provider	=>	'appdmg'
     })
   end

--- a/spec/classes/firefox-ux.rb
+++ b/spec/classes/firefox-ux.rb
@@ -4,7 +4,7 @@ describe 'firefox::ux' do
   it do
     should contain_class('firefox::ux')
     should contain_package('Firefox-UX').with({
-      :source	=>	'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-ux/firefox-24.0a1.en-US.mac.dmg',
+      :source	=>	'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-ux/firefox-26.0a1.en-US.mac.dmg',
       :provider	=>	'appdmg'
     })
   end

--- a/spec/classes/firefox_spec.rb
+++ b/spec/classes/firefox_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox' do
   it do
     should contain_class('firefox')
     should contain_package('Firefox').with({
-      :source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/22.0/mac/en-US/Firefox%2022.0.dmg",
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0/mac/en-US/Firefox%2023.0.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
The Firefox versions for all the classes in this module are at least one or two major revisions behind.  This PR merges in some more current URLs.
