### PR TITLE
firefox 23.0.1 stable version bump

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 #   include firefox
 class firefox($locale = 'en-US'){
   package { 'Firefox':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0/mac/${locale}/Firefox%2023.0.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0.1/mac/${locale}/Firefox%2023.0.1.dmg",
     provider => 'appdmg'
   }
 }

--- a/spec/classes/firefox_spec.rb
+++ b/spec/classes/firefox_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox' do
   it do
     should contain_class('firefox')
     should contain_package('Firefox').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0/mac/en-US/Firefox%2023.0.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/23.0.1/mac/en-US/Firefox%2023.0.1.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
Firefox release 23.0.1 stable. This PR contains the updated URLs.
