### PR TITLE
another set of trains have left the station

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ include firefox
 include firefox::nightly
 # firefox::beta & firefox::aurora available
 
-# bonus! UX nightly builds
-include firefox::ux
-
 # for a custom version of the release channel
 class { 'firefox':
   version => '26.0b1'

--- a/manifests/aurora.pp
+++ b/manifests/aurora.pp
@@ -5,7 +5,7 @@
 #   include firefox::aurora
 class firefox::aurora ($locale = 'en-US'){
   package { 'Firefox-Aurora':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-27.0a2.${locale}.mac.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-28.0a2.${locale}.mac.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/beta.pp
+++ b/manifests/beta.pp
@@ -5,7 +5,7 @@
 #   include firefox::beta
 class firefox::beta ($locale = 'en-US'){
   package { 'Firefox-Beta':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/26.0b8/mac/${locale}/Firefox%2026.0b8.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-beta/mac/${locale}/Firefox%2027.0b1.dmg",
     provider => 'appdmg'
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 # Examples
 #
 #   include firefox
-class firefox($locale = 'en-US', $version = '25.0'){
+class firefox($locale = 'en-US', $version = '26.0'){
   package { 'Firefox':
     source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/${version}/mac/${locale}/Firefox%20${version}.dmg",
     provider => 'appdmg'

--- a/manifests/nightly.pp
+++ b/manifests/nightly.pp
@@ -5,7 +5,7 @@
 #   include firefox::nightly
 class firefox::nightly ($locale = 'en-US'){
   package { 'Firefox-Nightly':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-28.0a1.${locale}.mac.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-29.0a1.${locale}.mac.dmg",
     provider => 'appdmg'
   }
 }

--- a/spec/classes/firefox-aurora_spec.rb
+++ b/spec/classes/firefox-aurora_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::aurora' do
   it do
     should contain_class('firefox::aurora')
     should contain_package('Firefox-Aurora').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-27.0a2.en-US.mac.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/firefox-28.0a2.en-US.mac.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/classes/firefox-beta_spec.rb
+++ b/spec/classes/firefox-beta_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::beta' do
   it do
     should contain_class('firefox::beta')
     should contain_package('Firefox-Beta').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/26.0b8/mac/en-US/Firefox%2026.0b8.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-beta/mac/en-US/Firefox%2027.0b1.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/classes/firefox-nightly_spec.rb
+++ b/spec/classes/firefox-nightly_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::nightly' do
   it do
     should contain_class('firefox::nightly')
     should contain_package('Firefox-Nightly').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-28.0a1.en-US.mac.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-trunk/firefox-29.0a1.en-US.mac.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/classes/firefox_spec.rb
+++ b/spec/classes/firefox_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox' do
   it do
     should contain_class('firefox')
     should contain_package('Firefox').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/25.0/mac/en-US/Firefox%2025.0.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/26.0/mac/en-US/Firefox%2026.0.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
Time to bump the version numbers again. This also removes the now non-existent UX channel from the `README` and standardizes using `/latest-*/` aliases for non-release channels.
