### PR TITLE
revert to using hardcoded beta path

### DIFF
--- a/manifests/beta.pp
+++ b/manifests/beta.pp
@@ -5,7 +5,7 @@
 #   include firefox::beta
 class firefox::beta ($locale = 'en-US'){
   package { 'Firefox-Beta':
-    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-beta/mac/${locale}/Firefox%2027.0b1.dmg",
+    source   => "http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/27.0b2/mac/${locale}/Firefox%2027.0b2.dmg",
     provider => 'appdmg'
   }
 }

--- a/spec/classes/firefox-beta_spec.rb
+++ b/spec/classes/firefox-beta_spec.rb
@@ -4,7 +4,7 @@ describe 'firefox::beta' do
   it do
     should contain_class('firefox::beta')
     should contain_package('Firefox-Beta').with({
-      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-beta/mac/en-US/Firefox%2027.0b1.dmg',
+      :source   => 'http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/27.0b2/mac/en-US/Firefox%2027.0b2.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
ftp.mozilla uses inconsistent naming in its file paths. The alias to latest-beta will result in errors when a new beta is released (potentially daily) until puppet-firefox has been updated. This resolves the issue by reverting the beta path so that it is pinned to a specific version. We can rely on Firefox's internal updater to keep things fresh in between train switch releases.
